### PR TITLE
Add AgentManager.chat() for session-scoped agent chat

### DIFF
--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -219,6 +219,23 @@ declare class AgentManager {
     create(input: AgentCreateInput): Promise<AgentCreateResult>;
     request(agentId: string, input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
     message(agentId: string, message: any): Promise<AgentMessageResult>;
+    /**
+     * Send a message to an agent and synchronously await its next response on the session.
+     *
+     * Session lifecycle:
+     * - Omit `sessionId` on the first call — the server mints a new session and returns
+     *   its id in the result. Capture it.
+     * - Pass the returned `sessionId` on every subsequent call to continue the conversation.
+     * - An unknown `sessionId` is rejected (the server will not silently mint one); omit
+     *   the field entirely to start a new session.
+     *
+     * Concurrency: only one chat may be in flight per session. Concurrent calls on the
+     * same session are rejected by the venue.
+     *
+     * Blocking: always blocks until the agent produces its next response on the session.
+     * No polling required.
+     */
+    chat(agentId: string, message: any, sessionId?: string): Promise<AgentChatResult>;
     trigger(agentId: string): Promise<AgentTriggerResult>;
     query(agentId: string): Promise<AgentQueryResult>;
     list(includeTerminated?: boolean): Promise<AgentListResult>;
@@ -678,6 +695,16 @@ interface AgentMessageResult {
     agentId: string;
     delivered: boolean;
 }
+interface AgentChatInput {
+    agentId: string;
+    message: any;
+    sessionId?: string;
+}
+interface AgentChatResult {
+    agentId: string;
+    sessionId: string;
+    response: any;
+}
 interface AgentTriggerInput {
     agentId: string;
 }
@@ -1010,4 +1037,4 @@ declare function decodePublicKey(multikey: string): Uint8Array;
  */
 declare function didFromPublicKey(publicKey: Uint8Array): string;
 
-export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };
+export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -219,6 +219,23 @@ declare class AgentManager {
     create(input: AgentCreateInput): Promise<AgentCreateResult>;
     request(agentId: string, input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
     message(agentId: string, message: any): Promise<AgentMessageResult>;
+    /**
+     * Send a message to an agent and synchronously await its next response on the session.
+     *
+     * Session lifecycle:
+     * - Omit `sessionId` on the first call — the server mints a new session and returns
+     *   its id in the result. Capture it.
+     * - Pass the returned `sessionId` on every subsequent call to continue the conversation.
+     * - An unknown `sessionId` is rejected (the server will not silently mint one); omit
+     *   the field entirely to start a new session.
+     *
+     * Concurrency: only one chat may be in flight per session. Concurrent calls on the
+     * same session are rejected by the venue.
+     *
+     * Blocking: always blocks until the agent produces its next response on the session.
+     * No polling required.
+     */
+    chat(agentId: string, message: any, sessionId?: string): Promise<AgentChatResult>;
     trigger(agentId: string): Promise<AgentTriggerResult>;
     query(agentId: string): Promise<AgentQueryResult>;
     list(includeTerminated?: boolean): Promise<AgentListResult>;
@@ -678,6 +695,16 @@ interface AgentMessageResult {
     agentId: string;
     delivered: boolean;
 }
+interface AgentChatInput {
+    agentId: string;
+    message: any;
+    sessionId?: string;
+}
+interface AgentChatResult {
+    agentId: string;
+    sessionId: string;
+    response: any;
+}
 interface AgentTriggerInput {
     agentId: string;
 }
@@ -1010,4 +1037,4 @@ declare function decodePublicKey(multikey: string): Uint8Array;
  */
 declare function didFromPublicKey(publicKey: Uint8Array): string;
 
-export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };
+export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1350,6 +1350,25 @@ var AgentManager = class {
   async message(agentId, message) {
     return this.venue.operations.run("v/ops/agent/message", { agentId, message });
   }
+  /**
+   * Send a message to an agent and synchronously await its next response on the session.
+   *
+   * Session lifecycle:
+   * - Omit `sessionId` on the first call — the server mints a new session and returns
+   *   its id in the result. Capture it.
+   * - Pass the returned `sessionId` on every subsequent call to continue the conversation.
+   * - An unknown `sessionId` is rejected (the server will not silently mint one); omit
+   *   the field entirely to start a new session.
+   *
+   * Concurrency: only one chat may be in flight per session. Concurrent calls on the
+   * same session are rejected by the venue.
+   *
+   * Blocking: always blocks until the agent produces its next response on the session.
+   * No polling required.
+   */
+  async chat(agentId, message, sessionId) {
+    return this.venue.operations.run("v/ops/agent/chat", { agentId, message, sessionId });
+  }
   async trigger(agentId) {
     return this.venue.operations.run("v/ops/agent/trigger", { agentId });
   }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1348,6 +1348,25 @@ var AgentManager = class {
   async message(agentId, message) {
     return this.venue.operations.run("v/ops/agent/message", { agentId, message });
   }
+  /**
+   * Send a message to an agent and synchronously await its next response on the session.
+   *
+   * Session lifecycle:
+   * - Omit `sessionId` on the first call — the server mints a new session and returns
+   *   its id in the result. Capture it.
+   * - Pass the returned `sessionId` on every subsequent call to continue the conversation.
+   * - An unknown `sessionId` is rejected (the server will not silently mint one); omit
+   *   the field entirely to start a new session.
+   *
+   * Concurrency: only one chat may be in flight per session. Concurrent calls on the
+   * same session are rejected by the venue.
+   *
+   * Blocking: always blocks until the agent produces its next response on the session.
+   * No polling required.
+   */
+  async chat(agentId, message, sessionId) {
+    return this.venue.operations.run("v/ops/agent/chat", { agentId, message, sessionId });
+  }
   async trigger(agentId) {
     return this.venue.operations.run("v/ops/agent/trigger", { agentId });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covia/covia-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Typescript library for covia-ai",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/AgentManager.ts
+++ b/src/AgentManager.ts
@@ -1,4 +1,4 @@
-import { AgentCreateInput, AgentCreateResult, AgentRequestResult, AgentMessageResult, AgentTriggerResult, AgentQueryResult, AgentListResult, AgentDeleteResult, AgentSuspendResult, AgentUpdateInput } from './types';
+import { AgentCreateInput, AgentCreateResult, AgentRequestResult, AgentMessageResult, AgentChatResult, AgentTriggerResult, AgentQueryResult, AgentListResult, AgentDeleteResult, AgentSuspendResult, AgentUpdateInput } from './types';
 
 interface AgentManagerVenue {
   operations: { run(assetId: string, input: any): Promise<any> };
@@ -17,6 +17,26 @@ export class AgentManager {
 
   async message(agentId: string, message: any): Promise<AgentMessageResult> {
     return this.venue.operations.run('v/ops/agent/message', { agentId, message });
+  }
+
+  /**
+   * Send a message to an agent and synchronously await its next response on the session.
+   *
+   * Session lifecycle:
+   * - Omit `sessionId` on the first call — the server mints a new session and returns
+   *   its id in the result. Capture it.
+   * - Pass the returned `sessionId` on every subsequent call to continue the conversation.
+   * - An unknown `sessionId` is rejected (the server will not silently mint one); omit
+   *   the field entirely to start a new session.
+   *
+   * Concurrency: only one chat may be in flight per session. Concurrent calls on the
+   * same session are rejected by the venue.
+   *
+   * Blocking: always blocks until the agent produces its next response on the session.
+   * No polling required.
+   */
+  async chat(agentId: string, message: any, sessionId?: string): Promise<AgentChatResult> {
+    return this.venue.operations.run('v/ops/agent/chat', { agentId, message, sessionId });
   }
 
   async trigger(agentId: string): Promise<AgentTriggerResult> {

--- a/src/__tests__/AgentManager.test.ts
+++ b/src/__tests__/AgentManager.test.ts
@@ -30,6 +30,21 @@ describe('AgentManager', () => {
     expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/message', { agentId: 'a1', message: { text: 'hello' } });
   });
 
+  it('chat calls v/ops/agent/chat without sessionId on first call', async () => {
+    await agents.chat('a1', 'hello');
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/chat', { agentId: 'a1', message: 'hello', sessionId: undefined });
+  });
+
+  it('chat passes sessionId when continuing a session', async () => {
+    await agents.chat('a1', 'follow up', 'deadbeef');
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/chat', { agentId: 'a1', message: 'follow up', sessionId: 'deadbeef' });
+  });
+
+  it('chat passes structured message payloads through unchanged', async () => {
+    await agents.chat('a1', { kind: 'tool-result', data: [1, 2, 3] }, 'sid-1');
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/chat', { agentId: 'a1', message: { kind: 'tool-result', data: [1, 2, 3] }, sessionId: 'sid-1' });
+  });
+
   it('trigger calls v/ops/agent/trigger', async () => {
     await agents.trigger('a1');
     expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/trigger', { agentId: 'a1' });

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,18 @@ export interface AgentMessageResult {
   delivered: boolean;
 }
 
+export interface AgentChatInput {
+  agentId: string;
+  message: any;
+  sessionId?: string;
+}
+
+export interface AgentChatResult {
+  agentId: string;
+  sessionId: string;
+  response: any;
+}
+
 export interface AgentTriggerInput {
   agentId: string;
 }


### PR DESCRIPTION
## Summary

- Adds `AgentManager.chat(agentId, message, sessionId?)` wrapping `v/ops/agent/chat`
- Adds `AgentChatInput` / `AgentChatResult` types
- Bumps version 1.3.0 → 1.4.0 (additive, no breaking changes)

Unblocks GetMine-ai/demo#18 — the demo client can now use session-scoped chat instead of bypassing the SDK with `operations.run(...)` directly.

Closes #4

## Test plan

- [x] 3 new unit tests in `src/__tests__/AgentManager.test.ts` — first call without sessionId, continuation with sessionId, structured message payload
- [x] `pnpm exec jest src/__tests__/AgentManager.test.ts` — 15/15 pass (12 original + 3 new)
- [x] `pnpm run build` — clean; `chat`, `AgentChatInput`, `AgentChatResult` present in `dist/index.d.ts`
- [x] Full suite: 137/138 pass — same as baseline on `main` (the 1 pre-existing failure is `@noble/ed25519` ESM import in crypto tests, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)