### PR TITLE
Unblock publish: fix jest ESM transform, scope prepublishOnly, document chat()

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ await venue.agents.message("my-agent", { event: "update" });
 await venue.agents.trigger("my-agent");
 const state = await venue.agents.query("my-agent");
 
+// Session-scoped chat — mints a session on the first call, continue by echoing sessionId
+const first = await venue.agents.chat("my-agent", "hi");
+const follow = await venue.agents.chat("my-agent", "and now?", first.sessionId);
+
 // Lifecycle
 const agents = await venue.agents.list();
 await venue.agents.suspend("my-agent");
@@ -351,6 +355,7 @@ await venue.agents.delete("my-agent");
 | `agents.create(input)` | `AgentCreateResult` | Create an agent |
 | `agents.request(id, input?, wait?)` | `AgentRequestResult` | Send request to agent |
 | `agents.message(id, message)` | `AgentMessageResult` | Send a message |
+| `agents.chat(id, message, sessionId?)` | `AgentChatResult` | Session-scoped chat — awaits next response on the session |
 | `agents.trigger(id)` | `AgentTriggerResult` | Trigger agent execution |
 | `agents.query(id)` | `AgentQueryResult` | Query agent state |
 | `agents.list(includeTerminated?)` | `AgentListResult` | List agents |

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,9 +8,18 @@ module.exports = {
   setupFiles: ["dotenv/config"],
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { useESM: false }],
-    "^.+\\.jsx?$": ["ts-jest", { useESM: false }],
+    "^.+\\.jsx?$": ["ts-jest", {
+      useESM: false,
+      tsconfig: {
+        allowJs: true,
+        module: "commonjs",
+        target: "ES2020",
+        moduleResolution: "node",
+        esModuleInterop: true,
+      },
+    }],
   },
   transformIgnorePatterns: [
-    "node_modules/(?!(@noble/ed25519|@noble/hashes)/)",
+    "^(?!.*@noble[/+](ed25519|hashes)).*node_modules",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:unit": "jest src/__tests__/",
     "test:integration": "jest venue.test.ts",
-    "prepublishOnly": "npm run build && npm test",
+    "prepublishOnly": "npm run build && npm run test:unit",
     "prepare": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Three prerequisites for publishing 1.4.0 to npm:

1. **`jest.config.js`** — anchor-based `transformIgnorePatterns` so `@noble/ed25519` and `@noble/hashes` are actually transformed under pnpm's `.pnpm/…/node_modules/@noble/ed25519/` layout. The old pattern matched the first of the two `node_modules/` segments (whose follower is `.pnpm/`, not `@noble/ed25519/`), so the negative lookahead passed and the ESM file was ignored. Also added `allowJs: true` + `module: "commonjs"` on the JS transform so ts-jest actually emits CJS for these modules.
2. **`package.json`** — `prepublishOnly` runs `test:unit` rather than the full `test`. `venue.test.ts` is a live integration suite that requires `VENUE_HOST` + a running venue, so leaving it in `prepublishOnly` meant `npm publish` always failed.
3. **`README.md`** — document `agents.chat()` in the code example block and the method reference table. Follow-up to #5 which shipped the method but didn't update docs.

## Test plan

- [x] `pnpm run test:unit` — 12/12 suites, 210/210 tests pass (was 134/135 with 4 suites failing before the jest fix)
- [x] `pnpm run build` — clean
- [x] `pnpm exec jest src/__tests__/Credentials.test.ts` — now passes (was the canary for the ESM issue)
- [ ] Operator should run `npm publish --dry-run` locally to confirm `prepublishOnly` completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)