### PR TITLE
Add Agent and ChatSession classes for OO agent interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ venue.metadata;   // { name, description }
 | `venue.status()` | Get venue status (health, stats) |
 | `venue.getAsset(assetId)` | Get an asset by ID (returns `Operation` or `DataAsset`) |
 | `venue.listAssets(options?)` | List assets with pagination (`{ offset, limit }`) |
+| `venue.agent(agentId)` | Get a lazy `Agent` handle (no round-trip) |
 | `venue.getJob(jobId)` | Get a job by ID |
 | `venue.listJobs()` | List all job IDs |
 | `venue.didDocument()` | Get the venue's DID document |
@@ -320,50 +321,100 @@ const job = await asset.invoke({ param: "value" });       // async → Job
 
 ---
 
-### Agents — `venue.agents`
+### Agents — `venue.agent(id)` / `venue.agents`
 
-Create and manage persistent AI agents.
+The preferred way to work with agents is through the `Agent` instance returned by `venue.agent(id)`. This is a lazy handle — no network call is made until you invoke a method.
+
+```typescript
+// Get a handle to an agent (no round-trip)
+const mina = venue.agent("Mina");
+
+// Interact
+const response = await mina.request({ text: "hello" });
+await mina.message({ event: "update" });
+await mina.trigger();
+const state = await mina.query();
+const info = await mina.info();
+
+// Session-scoped chat — ChatSession manages the sessionId for you
+const chat = mina.chatSession();
+await chat.send("hi");          // mints a new session
+await chat.send("and now?");    // reuses the session automatically
+chat.sessionId;                 // available for persistence
+
+// Resume a previous session
+const resumed = mina.chatSession(storedSessionId);
+await resumed.send("I'm back");
+
+// Lifecycle
+await mina.suspend();
+await mina.resume();
+await mina.update({ config: { model: "gpt-4" } });
+await mina.cancelTask("task-123");
+await mina.delete();
+
+// Fork into a new agent
+const clone = await mina.fork("Mina-v2", { includeTimeline: true });
+```
+
+#### Agent Instance
+
+| Method | Returns | Description |
+|---|---|---|
+| `agent.request(input?, wait?)` | `AgentRequestResult` | Send request to agent |
+| `agent.message(message)` | `AgentMessageResult` | Send a message |
+| `agent.chat(message, sessionId?)` | `AgentChatResult` | Single chat call (manual sessionId) |
+| `agent.chatSession(sessionId?)` | `ChatSession` | Create a session that manages sessionId |
+| `agent.trigger()` | `AgentTriggerResult` | Trigger agent execution |
+| `agent.query()` | `AgentQueryResult` | Query agent state |
+| `agent.info()` | `AgentInfoResult` | Get agent info |
+| `agent.context(task?)` | `string` | Get agent context |
+| `agent.suspend()` | `AgentSuspendResult` | Suspend the agent |
+| `agent.resume(autoWake?)` | `AgentSuspendResult` | Resume the agent |
+| `agent.update(options)` | `any` | Update agent config/state |
+| `agent.cancelTask(taskId)` | `any` | Cancel an agent task |
+| `agent.fork(agentId, options?)` | `Agent` | Fork into a new agent |
+| `agent.delete(remove?)` | `AgentDeleteResult` | Delete the agent |
+
+#### ChatSession
+
+| Property / Method | Type | Description |
+|---|---|---|
+| `chat.sessionId` | `string \| undefined` | Current session ID (undefined until first send) |
+| `chat.send(message)` | `Promise<AgentChatResult>` | Send a message, auto-managing sessionId |
+
+#### AgentManager — `venue.agents`
+
+The `AgentManager` is still available for collection-level operations and flat-style dispatch.
 
 ```typescript
 // Create an agent
-const result = await venue.agents.create({
-  agentId: "my-agent",
-  config: { model: "gpt-4", instructions: "..." },
-});
+await venue.agents.create({ agentId: "my-agent", config: { ... } });
 
-// Interact with an agent
-const response = await venue.agents.request("my-agent", { text: "hello" });
-await venue.agents.message("my-agent", { event: "update" });
-await venue.agents.trigger("my-agent");
-const state = await venue.agents.query("my-agent");
-
-// Session-scoped chat — mints a session on the first call, continue by echoing sessionId
-const first = await venue.agents.chat("my-agent", "hi");
-const follow = await venue.agents.chat("my-agent", "and now?", first.sessionId);
-
-// Lifecycle
+// List agents
 const agents = await venue.agents.list();
-await venue.agents.suspend("my-agent");
-await venue.agents.resume("my-agent");
-await venue.agents.update({ agentId: "my-agent", config: { ... } });
-await venue.agents.cancelTask("my-agent", "task-123");
-await venue.agents.delete("my-agent");
+
+// Flat-style dispatch (all manager methods still work)
+await venue.agents.chat("my-agent", "hi");
 ```
 
 | Method | Returns | Description |
 |---|---|---|
 | `agents.create(input)` | `AgentCreateResult` | Create an agent |
+| `agents.list(includeTerminated?)` | `AgentListResult` | List agents |
 | `agents.request(id, input?, wait?)` | `AgentRequestResult` | Send request to agent |
 | `agents.message(id, message)` | `AgentMessageResult` | Send a message |
-| `agents.chat(id, message, sessionId?)` | `AgentChatResult` | Session-scoped chat — awaits next response on the session |
+| `agents.chat(id, message, sessionId?)` | `AgentChatResult` | Session-scoped chat |
 | `agents.trigger(id)` | `AgentTriggerResult` | Trigger agent execution |
 | `agents.query(id)` | `AgentQueryResult` | Query agent state |
-| `agents.list(includeTerminated?)` | `AgentListResult` | List agents |
-| `agents.delete(id, remove?)` | `AgentDeleteResult` | Delete an agent |
+| `agents.info(id)` | `AgentInfoResult` | Get agent info |
 | `agents.suspend(id)` | `AgentSuspendResult` | Suspend an agent |
 | `agents.resume(id, autoWake?)` | `AgentSuspendResult` | Resume an agent |
 | `agents.update(input)` | `any` | Update agent config/state |
 | `agents.cancelTask(agentId, taskId)` | `any` | Cancel an agent task |
+| `agents.fork(input)` | `AgentForkResult` | Fork an agent |
+| `agents.context(id, task?)` | `string` | Get agent context |
+| `agents.delete(id, remove?)` | `AgentDeleteResult` | Delete an agent |
 
 ---
 
@@ -513,7 +564,7 @@ RunStatus.AUTH_REQUIRED;   // Waiting for authentication
 
 ```typescript
 import {
-  Venue, Grid, Job, Asset, Operation, DataAsset,
+  Venue, Grid, Job, Agent, ChatSession, Asset, Operation, DataAsset,
   AssetManager, OperationManager, JobManager,
   AgentManager, WorkspaceManager, SecretManager, UCANManager,
   KeyPairAuth, BearerAuth,

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -416,6 +416,57 @@ declare class SecretManager {
     delete(name: string): Promise<void>;
 }
 
+declare class Agent {
+    readonly id: string;
+    readonly venue: VenueInterface;
+    private _agents;
+    constructor(id: string, venue: VenueInterface);
+    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
+    message(message: any): Promise<AgentMessageResult>;
+    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
+    /**
+     * Create a ChatSession bound to this agent.
+     * @param sessionId - Optional session ID to resume an existing session
+     */
+    chatSession(sessionId?: string): ChatSession;
+    trigger(): Promise<AgentTriggerResult>;
+    query(): Promise<AgentQueryResult>;
+    suspend(): Promise<AgentSuspendResult>;
+    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
+    update(options: {
+        config?: Record<string, any>;
+        state?: Record<string, any>;
+    }): Promise<any>;
+    cancelTask(taskId: string): Promise<any>;
+    info(): Promise<AgentInfoResult>;
+    /**
+     * Fork this agent into a new agent.
+     * @param agentId - ID for the new forked agent
+     * @param options - Fork options
+     * @returns A new Agent instance for the forked agent
+     */
+    fork(agentId: string, options?: {
+        config?: Record<string, any>;
+        includeTimeline?: boolean;
+        overwrite?: boolean;
+    }): Promise<Agent>;
+    context(task?: any): Promise<string>;
+    delete(remove?: boolean): Promise<AgentDeleteResult>;
+}
+declare class ChatSession {
+    readonly agent: Agent;
+    private _sessionId;
+    constructor(agent: Agent, sessionId?: string);
+    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+    get sessionId(): string | undefined;
+    /**
+     * Send a message on this session.
+     * On the first call (when no sessionId is set), the server mints a new session.
+     * The returned sessionId is captured and reused for all subsequent calls.
+     */
+    send(message: any): Promise<AgentChatResult>;
+}
+
 declare class Venue implements VenueInterface {
     baseUrl: string;
     venueId: string;
@@ -466,6 +517,13 @@ declare class Venue implements VenueInterface {
      * @returns {Promise<Job>}
      */
     getJob(jobId: string): Promise<Job>;
+    /**
+     * Get a lazy Agent handle for the given agent ID.
+     * No network round-trip — the agent is not verified to exist.
+     * @param agentId - Agent identifier
+     * @returns {Agent} An Agent instance bound to this venue
+     */
+    agent(agentId: string): Agent;
     /**
      * List secret names
      * @returns {Promise<string[]>}
@@ -1104,4 +1162,4 @@ declare function decodePublicKey(multikey: string): Uint8Array;
  */
 declare function didFromPublicKey(publicKey: Uint8Array): string;
 
-export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCompleteTaskResult, type AgentContextInput, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentFailTaskResult, type AgentForkInput, type AgentForkResult, type AgentInfoResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, type AssetPinResult, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceCopyResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceInspectInput, type WorkspaceInspectResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };
+export { type AdapterInfo, type AdaptersResult, Agent, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCompleteTaskResult, type AgentContextInput, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentFailTaskResult, type AgentForkInput, type AgentForkResult, type AgentInfoResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, type AssetPinResult, Auth, BearerAuth, ChatSession, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceCopyResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceInspectInput, type WorkspaceInspectResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };

--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1,3 +1,54 @@
+declare class Agent {
+    readonly id: string;
+    readonly venue: VenueInterface;
+    private _agents;
+    constructor(id: string, venue: VenueInterface);
+    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
+    message(message: any): Promise<AgentMessageResult>;
+    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
+    /**
+     * Create a ChatSession bound to this agent.
+     * @param sessionId - Optional session ID to resume an existing session
+     */
+    chatSession(sessionId?: string): ChatSession;
+    trigger(): Promise<AgentTriggerResult>;
+    query(): Promise<AgentQueryResult>;
+    suspend(): Promise<AgentSuspendResult>;
+    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
+    update(options: {
+        config?: Record<string, any>;
+        state?: Record<string, any>;
+    }): Promise<any>;
+    cancelTask(taskId: string): Promise<any>;
+    info(): Promise<AgentInfoResult>;
+    /**
+     * Fork this agent into a new agent.
+     * @param agentId - ID for the new forked agent
+     * @param options - Fork options
+     * @returns A new Agent instance for the forked agent
+     */
+    fork(agentId: string, options?: {
+        config?: Record<string, any>;
+        includeTimeline?: boolean;
+        overwrite?: boolean;
+    }): Promise<Agent>;
+    context(task?: any): Promise<string>;
+    delete(remove?: boolean): Promise<AgentDeleteResult>;
+}
+declare class ChatSession {
+    readonly agent: Agent;
+    private _sessionId;
+    constructor(agent: Agent, sessionId?: string);
+    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+    get sessionId(): string | undefined;
+    /**
+     * Send a message on this session.
+     * On the first call (when no sessionId is set), the server mints a new session.
+     * The returned sessionId is captured and reused for all subsequent calls.
+     */
+    send(message: any): Promise<AgentChatResult>;
+}
+
 declare class Job {
     id: string;
     venue: VenueInterface;
@@ -416,57 +467,6 @@ declare class SecretManager {
     delete(name: string): Promise<void>;
 }
 
-declare class Agent {
-    readonly id: string;
-    readonly venue: VenueInterface;
-    private _agents;
-    constructor(id: string, venue: VenueInterface);
-    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
-    message(message: any): Promise<AgentMessageResult>;
-    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
-    /**
-     * Create a ChatSession bound to this agent.
-     * @param sessionId - Optional session ID to resume an existing session
-     */
-    chatSession(sessionId?: string): ChatSession;
-    trigger(): Promise<AgentTriggerResult>;
-    query(): Promise<AgentQueryResult>;
-    suspend(): Promise<AgentSuspendResult>;
-    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
-    update(options: {
-        config?: Record<string, any>;
-        state?: Record<string, any>;
-    }): Promise<any>;
-    cancelTask(taskId: string): Promise<any>;
-    info(): Promise<AgentInfoResult>;
-    /**
-     * Fork this agent into a new agent.
-     * @param agentId - ID for the new forked agent
-     * @param options - Fork options
-     * @returns A new Agent instance for the forked agent
-     */
-    fork(agentId: string, options?: {
-        config?: Record<string, any>;
-        includeTimeline?: boolean;
-        overwrite?: boolean;
-    }): Promise<Agent>;
-    context(task?: any): Promise<string>;
-    delete(remove?: boolean): Promise<AgentDeleteResult>;
-}
-declare class ChatSession {
-    readonly agent: Agent;
-    private _sessionId;
-    constructor(agent: Agent, sessionId?: string);
-    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
-    get sessionId(): string | undefined;
-    /**
-     * Send a message on this session.
-     * On the first call (when no sessionId is set), the server mints a new session.
-     * The returned sessionId is captured and reused for all subsequent calls.
-     */
-    send(message: any): Promise<AgentChatResult>;
-}
-
 declare class Venue implements VenueInterface {
     baseUrl: string;
     venueId: string;
@@ -602,6 +602,7 @@ interface VenueInterface {
     listSecrets(): Promise<string[]>;
     putSecret(name: string, value: string): Promise<void>;
     deleteSecret(name: string): Promise<void>;
+    agent(agentId: string): Agent;
     close(): void;
 }
 type AssetID = string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -416,6 +416,57 @@ declare class SecretManager {
     delete(name: string): Promise<void>;
 }
 
+declare class Agent {
+    readonly id: string;
+    readonly venue: VenueInterface;
+    private _agents;
+    constructor(id: string, venue: VenueInterface);
+    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
+    message(message: any): Promise<AgentMessageResult>;
+    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
+    /**
+     * Create a ChatSession bound to this agent.
+     * @param sessionId - Optional session ID to resume an existing session
+     */
+    chatSession(sessionId?: string): ChatSession;
+    trigger(): Promise<AgentTriggerResult>;
+    query(): Promise<AgentQueryResult>;
+    suspend(): Promise<AgentSuspendResult>;
+    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
+    update(options: {
+        config?: Record<string, any>;
+        state?: Record<string, any>;
+    }): Promise<any>;
+    cancelTask(taskId: string): Promise<any>;
+    info(): Promise<AgentInfoResult>;
+    /**
+     * Fork this agent into a new agent.
+     * @param agentId - ID for the new forked agent
+     * @param options - Fork options
+     * @returns A new Agent instance for the forked agent
+     */
+    fork(agentId: string, options?: {
+        config?: Record<string, any>;
+        includeTimeline?: boolean;
+        overwrite?: boolean;
+    }): Promise<Agent>;
+    context(task?: any): Promise<string>;
+    delete(remove?: boolean): Promise<AgentDeleteResult>;
+}
+declare class ChatSession {
+    readonly agent: Agent;
+    private _sessionId;
+    constructor(agent: Agent, sessionId?: string);
+    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+    get sessionId(): string | undefined;
+    /**
+     * Send a message on this session.
+     * On the first call (when no sessionId is set), the server mints a new session.
+     * The returned sessionId is captured and reused for all subsequent calls.
+     */
+    send(message: any): Promise<AgentChatResult>;
+}
+
 declare class Venue implements VenueInterface {
     baseUrl: string;
     venueId: string;
@@ -466,6 +517,13 @@ declare class Venue implements VenueInterface {
      * @returns {Promise<Job>}
      */
     getJob(jobId: string): Promise<Job>;
+    /**
+     * Get a lazy Agent handle for the given agent ID.
+     * No network round-trip — the agent is not verified to exist.
+     * @param agentId - Agent identifier
+     * @returns {Agent} An Agent instance bound to this venue
+     */
+    agent(agentId: string): Agent;
     /**
      * List secret names
      * @returns {Promise<string[]>}
@@ -1104,4 +1162,4 @@ declare function decodePublicKey(multikey: string): Uint8Array;
  */
 declare function didFromPublicKey(publicKey: Uint8Array): string;
 
-export { type AdapterInfo, type AdaptersResult, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCompleteTaskResult, type AgentContextInput, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentFailTaskResult, type AgentForkInput, type AgentForkResult, type AgentInfoResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, type AssetPinResult, Auth, BearerAuth, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceCopyResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceInspectInput, type WorkspaceInspectResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };
+export { type AdapterInfo, type AdaptersResult, Agent, type AgentCancelTaskInput, type AgentCard, type AgentChatInput, type AgentChatResult, type AgentCompleteTaskResult, type AgentContextInput, type AgentCreateInput, type AgentCreateResult, type AgentDeleteInput, type AgentDeleteResult, type AgentFailTaskResult, type AgentForkInput, type AgentForkResult, type AgentInfoResult, type AgentListInput, type AgentListResult, AgentManager, type AgentMessageInput, type AgentMessageResult, type AgentQueryInput, type AgentQueryResult, type AgentRequestInput, type AgentRequestResult, type AgentResumeInput, AgentStatus, type AgentSuspendResult, type AgentTriggerInput, type AgentTriggerResult, type AgentUpdateInput, Asset, type AssetID, type AssetList, type AssetListOptions, AssetManager, type AssetMetadata, AssetNotFoundError, type AssetPinResult, Auth, BearerAuth, ChatSession, type ContentDetails, type ContentHashResult, CoviaConnectionError, CoviaError, CoviaTimeoutError, type Credentials, CredentialsHTTP, type DIDDocument, DataAsset, type FunctionInfo, type FunctionsResult, Grid, GridError, type InvokeOptions, type InvokePayload, Job, JobFailedError, JobManager, type JobMetadata, JobNotFoundError, JobStatus, KeyPairAuth, type MCPDiscovery, NoAuth, NotFoundError, Operation, type OperationDetails, type OperationInfo, OperationManager, type OperationPayload, RunStatus, type SSEEvent, type SecretExtractInput, type SecretExtractResult, SecretManager, type SecretSetInput, type SecretSetResult, type StatsData, type StatusData, type UCANAttenuation, type UCANIssueInput, type UCANIssueResult, UCANManager, Venue, type VenueConstructor, type VenueData, type VenueInterface, type VenueOptions, type WorkspaceAppendInput, type WorkspaceAppendResult, type WorkspaceCopyResult, type WorkspaceDeleteInput, type WorkspaceDeleteResult, type WorkspaceInspectInput, type WorkspaceInspectResult, type WorkspaceListInput, type WorkspaceListResult, WorkspaceManager, type WorkspaceReadInput, type WorkspaceReadResult, type WorkspaceSliceInput, type WorkspaceSliceResult, type WorkspaceWriteInput, type WorkspaceWriteResult, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,54 @@
+declare class Agent {
+    readonly id: string;
+    readonly venue: VenueInterface;
+    private _agents;
+    constructor(id: string, venue: VenueInterface);
+    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
+    message(message: any): Promise<AgentMessageResult>;
+    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
+    /**
+     * Create a ChatSession bound to this agent.
+     * @param sessionId - Optional session ID to resume an existing session
+     */
+    chatSession(sessionId?: string): ChatSession;
+    trigger(): Promise<AgentTriggerResult>;
+    query(): Promise<AgentQueryResult>;
+    suspend(): Promise<AgentSuspendResult>;
+    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
+    update(options: {
+        config?: Record<string, any>;
+        state?: Record<string, any>;
+    }): Promise<any>;
+    cancelTask(taskId: string): Promise<any>;
+    info(): Promise<AgentInfoResult>;
+    /**
+     * Fork this agent into a new agent.
+     * @param agentId - ID for the new forked agent
+     * @param options - Fork options
+     * @returns A new Agent instance for the forked agent
+     */
+    fork(agentId: string, options?: {
+        config?: Record<string, any>;
+        includeTimeline?: boolean;
+        overwrite?: boolean;
+    }): Promise<Agent>;
+    context(task?: any): Promise<string>;
+    delete(remove?: boolean): Promise<AgentDeleteResult>;
+}
+declare class ChatSession {
+    readonly agent: Agent;
+    private _sessionId;
+    constructor(agent: Agent, sessionId?: string);
+    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+    get sessionId(): string | undefined;
+    /**
+     * Send a message on this session.
+     * On the first call (when no sessionId is set), the server mints a new session.
+     * The returned sessionId is captured and reused for all subsequent calls.
+     */
+    send(message: any): Promise<AgentChatResult>;
+}
+
 declare class Job {
     id: string;
     venue: VenueInterface;
@@ -416,57 +467,6 @@ declare class SecretManager {
     delete(name: string): Promise<void>;
 }
 
-declare class Agent {
-    readonly id: string;
-    readonly venue: VenueInterface;
-    private _agents;
-    constructor(id: string, venue: VenueInterface);
-    request(input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
-    message(message: any): Promise<AgentMessageResult>;
-    chat(message: any, sessionId?: string): Promise<AgentChatResult>;
-    /**
-     * Create a ChatSession bound to this agent.
-     * @param sessionId - Optional session ID to resume an existing session
-     */
-    chatSession(sessionId?: string): ChatSession;
-    trigger(): Promise<AgentTriggerResult>;
-    query(): Promise<AgentQueryResult>;
-    suspend(): Promise<AgentSuspendResult>;
-    resume(autoWake?: boolean): Promise<AgentSuspendResult>;
-    update(options: {
-        config?: Record<string, any>;
-        state?: Record<string, any>;
-    }): Promise<any>;
-    cancelTask(taskId: string): Promise<any>;
-    info(): Promise<AgentInfoResult>;
-    /**
-     * Fork this agent into a new agent.
-     * @param agentId - ID for the new forked agent
-     * @param options - Fork options
-     * @returns A new Agent instance for the forked agent
-     */
-    fork(agentId: string, options?: {
-        config?: Record<string, any>;
-        includeTimeline?: boolean;
-        overwrite?: boolean;
-    }): Promise<Agent>;
-    context(task?: any): Promise<string>;
-    delete(remove?: boolean): Promise<AgentDeleteResult>;
-}
-declare class ChatSession {
-    readonly agent: Agent;
-    private _sessionId;
-    constructor(agent: Agent, sessionId?: string);
-    /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
-    get sessionId(): string | undefined;
-    /**
-     * Send a message on this session.
-     * On the first call (when no sessionId is set), the server mints a new session.
-     * The returned sessionId is captured and reused for all subsequent calls.
-     */
-    send(message: any): Promise<AgentChatResult>;
-}
-
 declare class Venue implements VenueInterface {
     baseUrl: string;
     venueId: string;
@@ -602,6 +602,7 @@ interface VenueInterface {
     listSecrets(): Promise<string[]>;
     putSecret(name: string, value: string): Promise<void>;
     deleteSecret(name: string): Promise<void>;
+    agent(agentId: string): Agent;
     close(): void;
 }
 type AssetID = string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,7 +91,7 @@ var JobNotFoundError = class extends NotFoundError {
   }
 };
 
-// node_modules/.pnpm/@noble+ed25519@2.3.0/node_modules/@noble/ed25519/index.js
+// node_modules/@noble/ed25519/index.js
 var ed25519_CURVE = {
   p: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffedn,
   n: 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3edn,
@@ -537,7 +537,7 @@ var wNAF = (n) => {
   return { p, f };
 };
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/utils.js
+// node_modules/@noble/hashes/esm/utils.js
 function isBytes2(a) {
   return a instanceof Uint8Array || ArrayBuffer.isView(a) && a.constructor.name === "Uint8Array";
 }
@@ -590,7 +590,7 @@ function createHasher(hashCons) {
   return hashC;
 }
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/_md.js
+// node_modules/@noble/hashes/esm/_md.js
 function setBigUint64(view, byteOffset, value, isLE) {
   if (typeof view.setBigUint64 === "function")
     return view.setBigUint64(byteOffset, value, isLE);
@@ -712,7 +712,7 @@ var SHA512_IV = /* @__PURE__ */ Uint32Array.from([
   327033209
 ]);
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/_u64.js
+// node_modules/@noble/hashes/esm/_u64.js
 var U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
 var _32n = /* @__PURE__ */ BigInt(32);
 function fromBig(n, le = false) {
@@ -747,7 +747,7 @@ var add4H = (low, Ah, Bh, Ch, Dh) => Ah + Bh + Ch + Dh + (low / 2 ** 32 | 0) | 0
 var add5L = (Al, Bl, Cl, Dl, El) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0) + (El >>> 0);
 var add5H = (low, Ah, Bh, Ch, Dh, Eh) => Ah + Bh + Ch + Dh + Eh + (low / 2 ** 32 | 0) | 0;
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/sha2.js
+// node_modules/@noble/hashes/esm/sha2.js
 var K512 = /* @__PURE__ */ (() => split([
   "0x428a2f98d728ae22",
   "0x7137449123ef65cd",
@@ -947,7 +947,7 @@ var SHA512 = class extends HashMD {
 };
 var sha512 = /* @__PURE__ */ createHasher(() => new SHA512());
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/sha512.js
+// node_modules/@noble/hashes/esm/sha512.js
 var sha5122 = sha512;
 
 // src/crypto/keys.ts
@@ -1999,6 +1999,90 @@ var SecretManager = class {
     return this.venue.deleteSecret(name);
   }
 };
+
+// src/Agent.ts
+var Agent = class _Agent {
+  constructor(id, venue) {
+    this.id = id;
+    this.venue = venue;
+    this._agents = venue.agents;
+  }
+  async request(input, wait) {
+    return this._agents.request(this.id, input, wait);
+  }
+  async message(message) {
+    return this._agents.message(this.id, message);
+  }
+  async chat(message, sessionId) {
+    return this._agents.chat(this.id, message, sessionId);
+  }
+  /**
+   * Create a ChatSession bound to this agent.
+   * @param sessionId - Optional session ID to resume an existing session
+   */
+  chatSession(sessionId) {
+    return new ChatSession(this, sessionId);
+  }
+  async trigger() {
+    return this._agents.trigger(this.id);
+  }
+  async query() {
+    return this._agents.query(this.id);
+  }
+  async suspend() {
+    return this._agents.suspend(this.id);
+  }
+  async resume(autoWake) {
+    return this._agents.resume(this.id, autoWake);
+  }
+  async update(options) {
+    return this._agents.update({ agentId: this.id, ...options });
+  }
+  async cancelTask(taskId) {
+    return this._agents.cancelTask(this.id, taskId);
+  }
+  async info() {
+    return this._agents.info(this.id);
+  }
+  /**
+   * Fork this agent into a new agent.
+   * @param agentId - ID for the new forked agent
+   * @param options - Fork options
+   * @returns A new Agent instance for the forked agent
+   */
+  async fork(agentId, options) {
+    await this._agents.fork({ sourceId: this.id, agentId, ...options });
+    return new _Agent(agentId, this.venue);
+  }
+  async context(task) {
+    return this._agents.context(this.id, task);
+  }
+  async delete(remove) {
+    return this._agents.delete(this.id, remove);
+  }
+};
+var ChatSession = class {
+  constructor(agent, sessionId) {
+    this.agent = agent;
+    this._sessionId = sessionId;
+  }
+  /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+  get sessionId() {
+    return this._sessionId;
+  }
+  /**
+   * Send a message on this session.
+   * On the first call (when no sessionId is set), the server mints a new session.
+   * The returned sessionId is captured and reused for all subsequent calls.
+   */
+  async send(message) {
+    const result = await this.agent.chat(message, this._sessionId);
+    this._sessionId = result.sessionId;
+    return result;
+  }
+};
+
+// src/Venue.ts
 var webResolver = webDidResolver.getResolver();
 var resolver = new didResolver.Resolver(webResolver);
 var Venue = class _Venue {
@@ -2108,6 +2192,15 @@ var Venue = class _Venue {
     return this.jobs.get(jobId);
   }
   /**
+   * Get a lazy Agent handle for the given agent ID.
+   * No network round-trip — the agent is not verified to exist.
+   * @param agentId - Agent identifier
+   * @returns {Agent} An Agent instance bound to this venue
+   */
+  agent(agentId) {
+    return new Agent(agentId, this);
+  }
+  /**
    * List secret names
    * @returns {Promise<string[]>}
    */
@@ -2213,6 +2306,7 @@ var Grid = class {
   (*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) *)
 */
 
+exports.Agent = Agent;
 exports.AgentManager = AgentManager;
 exports.AgentStatus = AgentStatus;
 exports.Asset = Asset;
@@ -2220,6 +2314,7 @@ exports.AssetManager = AssetManager;
 exports.AssetNotFoundError = AssetNotFoundError;
 exports.Auth = Auth;
 exports.BearerAuth = BearerAuth;
+exports.ChatSession = ChatSession;
 exports.CoviaConnectionError = CoviaConnectionError;
 exports.CoviaError = CoviaError;
 exports.CoviaTimeoutError = CoviaTimeoutError;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -89,7 +89,7 @@ var JobNotFoundError = class extends NotFoundError {
   }
 };
 
-// node_modules/.pnpm/@noble+ed25519@2.3.0/node_modules/@noble/ed25519/index.js
+// node_modules/@noble/ed25519/index.js
 var ed25519_CURVE = {
   p: 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffedn,
   n: 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3edn,
@@ -535,7 +535,7 @@ var wNAF = (n) => {
   return { p, f };
 };
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/utils.js
+// node_modules/@noble/hashes/esm/utils.js
 function isBytes2(a) {
   return a instanceof Uint8Array || ArrayBuffer.isView(a) && a.constructor.name === "Uint8Array";
 }
@@ -588,7 +588,7 @@ function createHasher(hashCons) {
   return hashC;
 }
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/_md.js
+// node_modules/@noble/hashes/esm/_md.js
 function setBigUint64(view, byteOffset, value, isLE) {
   if (typeof view.setBigUint64 === "function")
     return view.setBigUint64(byteOffset, value, isLE);
@@ -710,7 +710,7 @@ var SHA512_IV = /* @__PURE__ */ Uint32Array.from([
   327033209
 ]);
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/_u64.js
+// node_modules/@noble/hashes/esm/_u64.js
 var U32_MASK64 = /* @__PURE__ */ BigInt(2 ** 32 - 1);
 var _32n = /* @__PURE__ */ BigInt(32);
 function fromBig(n, le = false) {
@@ -745,7 +745,7 @@ var add4H = (low, Ah, Bh, Ch, Dh) => Ah + Bh + Ch + Dh + (low / 2 ** 32 | 0) | 0
 var add5L = (Al, Bl, Cl, Dl, El) => (Al >>> 0) + (Bl >>> 0) + (Cl >>> 0) + (Dl >>> 0) + (El >>> 0);
 var add5H = (low, Ah, Bh, Ch, Dh, Eh) => Ah + Bh + Ch + Dh + Eh + (low / 2 ** 32 | 0) | 0;
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/sha2.js
+// node_modules/@noble/hashes/esm/sha2.js
 var K512 = /* @__PURE__ */ (() => split([
   "0x428a2f98d728ae22",
   "0x7137449123ef65cd",
@@ -945,7 +945,7 @@ var SHA512 = class extends HashMD {
 };
 var sha512 = /* @__PURE__ */ createHasher(() => new SHA512());
 
-// node_modules/.pnpm/@noble+hashes@1.8.0/node_modules/@noble/hashes/esm/sha512.js
+// node_modules/@noble/hashes/esm/sha512.js
 var sha5122 = sha512;
 
 // src/crypto/keys.ts
@@ -1997,6 +1997,90 @@ var SecretManager = class {
     return this.venue.deleteSecret(name);
   }
 };
+
+// src/Agent.ts
+var Agent = class _Agent {
+  constructor(id, venue) {
+    this.id = id;
+    this.venue = venue;
+    this._agents = venue.agents;
+  }
+  async request(input, wait) {
+    return this._agents.request(this.id, input, wait);
+  }
+  async message(message) {
+    return this._agents.message(this.id, message);
+  }
+  async chat(message, sessionId) {
+    return this._agents.chat(this.id, message, sessionId);
+  }
+  /**
+   * Create a ChatSession bound to this agent.
+   * @param sessionId - Optional session ID to resume an existing session
+   */
+  chatSession(sessionId) {
+    return new ChatSession(this, sessionId);
+  }
+  async trigger() {
+    return this._agents.trigger(this.id);
+  }
+  async query() {
+    return this._agents.query(this.id);
+  }
+  async suspend() {
+    return this._agents.suspend(this.id);
+  }
+  async resume(autoWake) {
+    return this._agents.resume(this.id, autoWake);
+  }
+  async update(options) {
+    return this._agents.update({ agentId: this.id, ...options });
+  }
+  async cancelTask(taskId) {
+    return this._agents.cancelTask(this.id, taskId);
+  }
+  async info() {
+    return this._agents.info(this.id);
+  }
+  /**
+   * Fork this agent into a new agent.
+   * @param agentId - ID for the new forked agent
+   * @param options - Fork options
+   * @returns A new Agent instance for the forked agent
+   */
+  async fork(agentId, options) {
+    await this._agents.fork({ sourceId: this.id, agentId, ...options });
+    return new _Agent(agentId, this.venue);
+  }
+  async context(task) {
+    return this._agents.context(this.id, task);
+  }
+  async delete(remove) {
+    return this._agents.delete(this.id, remove);
+  }
+};
+var ChatSession = class {
+  constructor(agent, sessionId) {
+    this.agent = agent;
+    this._sessionId = sessionId;
+  }
+  /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+  get sessionId() {
+    return this._sessionId;
+  }
+  /**
+   * Send a message on this session.
+   * On the first call (when no sessionId is set), the server mints a new session.
+   * The returned sessionId is captured and reused for all subsequent calls.
+   */
+  async send(message) {
+    const result = await this.agent.chat(message, this._sessionId);
+    this._sessionId = result.sessionId;
+    return result;
+  }
+};
+
+// src/Venue.ts
 var webResolver = getResolver();
 var resolver = new Resolver(webResolver);
 var Venue = class _Venue {
@@ -2106,6 +2190,15 @@ var Venue = class _Venue {
     return this.jobs.get(jobId);
   }
   /**
+   * Get a lazy Agent handle for the given agent ID.
+   * No network round-trip — the agent is not verified to exist.
+   * @param agentId - Agent identifier
+   * @returns {Agent} An Agent instance bound to this venue
+   */
+  agent(agentId) {
+    return new Agent(agentId, this);
+  }
+  /**
    * List secret names
    * @returns {Promise<string[]>}
    */
@@ -2211,4 +2304,4 @@ var Grid = class {
   (*! noble-hashes - MIT License (c) 2022 Paul Miller (paulmillr.com) *)
 */
 
-export { AgentManager, AgentStatus, Asset, AssetManager, AssetNotFoundError, Auth, BearerAuth, CoviaConnectionError, CoviaError, CoviaTimeoutError, CredentialsHTTP, DataAsset, Grid, GridError, Job, JobFailedError, JobManager, JobNotFoundError, JobStatus, KeyPairAuth, NoAuth, NotFoundError, Operation, OperationManager, RunStatus, SecretManager, UCANManager, Venue, WorkspaceManager, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };
+export { Agent, AgentManager, AgentStatus, Asset, AssetManager, AssetNotFoundError, Auth, BearerAuth, ChatSession, CoviaConnectionError, CoviaError, CoviaTimeoutError, CredentialsHTTP, DataAsset, Grid, GridError, Job, JobFailedError, JobManager, JobNotFoundError, JobStatus, KeyPairAuth, NoAuth, NotFoundError, Operation, OperationManager, RunStatus, SecretManager, UCANManager, Venue, WorkspaceManager, createSSEEvent, decodePublicKey, didFromPublicKey, encodePublicKey, fetchStreamWithError, fetchWithError, generateKeyPair, getAssetIdFromPath, getAssetIdFromVenueId, getParsedAssetId, hexToPrivateKey, isJobComplete, isJobFinished, isJobPaused, logger, parseSSEStream, privateKeyToHex };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covia/covia-sdk",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Typescript library for covia-ai",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -1,0 +1,136 @@
+import {
+  AgentRequestResult,
+  AgentMessageResult,
+  AgentChatResult,
+  AgentTriggerResult,
+  AgentQueryResult,
+  AgentSuspendResult,
+  AgentUpdateInput,
+  AgentInfoResult,
+  AgentForkInput,
+  AgentForkResult,
+  AgentDeleteResult,
+  VenueInterface,
+} from './types';
+
+/** Minimal interface for the agent operations Agent needs from the venue's AgentManager. */
+interface AgentOps {
+  request(agentId: string, input?: any, wait?: boolean | number): Promise<AgentRequestResult>;
+  message(agentId: string, message: any): Promise<AgentMessageResult>;
+  chat(agentId: string, message: any, sessionId?: string): Promise<AgentChatResult>;
+  trigger(agentId: string): Promise<AgentTriggerResult>;
+  query(agentId: string): Promise<AgentQueryResult>;
+  suspend(agentId: string): Promise<AgentSuspendResult>;
+  resume(agentId: string, autoWake?: boolean): Promise<AgentSuspendResult>;
+  update(input: AgentUpdateInput): Promise<any>;
+  cancelTask(agentId: string, taskId: string): Promise<any>;
+  info(agentId: string): Promise<AgentInfoResult>;
+  fork(input: AgentForkInput): Promise<AgentForkResult>;
+  context(agentId: string, task?: any): Promise<string>;
+  delete(agentId: string, remove?: boolean): Promise<AgentDeleteResult>;
+}
+
+export class Agent {
+  public readonly id: string;
+  public readonly venue: VenueInterface;
+  private _agents: AgentOps;
+
+  constructor(id: string, venue: VenueInterface) {
+    this.id = id;
+    this.venue = venue;
+    this._agents = (venue as any).agents;
+  }
+
+  async request(input?: any, wait?: boolean | number): Promise<AgentRequestResult> {
+    return this._agents.request(this.id, input, wait);
+  }
+
+  async message(message: any): Promise<AgentMessageResult> {
+    return this._agents.message(this.id, message);
+  }
+
+  async chat(message: any, sessionId?: string): Promise<AgentChatResult> {
+    return this._agents.chat(this.id, message, sessionId);
+  }
+
+  /**
+   * Create a ChatSession bound to this agent.
+   * @param sessionId - Optional session ID to resume an existing session
+   */
+  chatSession(sessionId?: string): ChatSession {
+    return new ChatSession(this, sessionId);
+  }
+
+  async trigger(): Promise<AgentTriggerResult> {
+    return this._agents.trigger(this.id);
+  }
+
+  async query(): Promise<AgentQueryResult> {
+    return this._agents.query(this.id);
+  }
+
+  async suspend(): Promise<AgentSuspendResult> {
+    return this._agents.suspend(this.id);
+  }
+
+  async resume(autoWake?: boolean): Promise<AgentSuspendResult> {
+    return this._agents.resume(this.id, autoWake);
+  }
+
+  async update(options: { config?: Record<string, any>; state?: Record<string, any> }): Promise<any> {
+    return this._agents.update({ agentId: this.id, ...options });
+  }
+
+  async cancelTask(taskId: string): Promise<any> {
+    return this._agents.cancelTask(this.id, taskId);
+  }
+
+  async info(): Promise<AgentInfoResult> {
+    return this._agents.info(this.id);
+  }
+
+  /**
+   * Fork this agent into a new agent.
+   * @param agentId - ID for the new forked agent
+   * @param options - Fork options
+   * @returns A new Agent instance for the forked agent
+   */
+  async fork(agentId: string, options?: { config?: Record<string, any>; includeTimeline?: boolean; overwrite?: boolean }): Promise<Agent> {
+    await this._agents.fork({ sourceId: this.id, agentId, ...options });
+    return new Agent(agentId, this.venue);
+  }
+
+  async context(task?: any): Promise<string> {
+    return this._agents.context(this.id, task);
+  }
+
+  async delete(remove?: boolean): Promise<AgentDeleteResult> {
+    return this._agents.delete(this.id, remove);
+  }
+}
+
+export class ChatSession {
+  public readonly agent: Agent;
+  private _sessionId: string | undefined;
+
+  constructor(agent: Agent, sessionId?: string) {
+    this.agent = agent;
+    this._sessionId = sessionId;
+  }
+
+  /** The session ID, or undefined if no message has been sent yet and no ID was provided. */
+  get sessionId(): string | undefined {
+    return this._sessionId;
+  }
+
+  /**
+   * Send a message on this session.
+   * On the first call (when no sessionId is set), the server mints a new session.
+   * The returned sessionId is captured and reused for all subsequent calls.
+   */
+  async send(message: any): Promise<AgentChatResult> {
+    const result = await this.agent.chat(message, this._sessionId);
+    this._sessionId = result.sessionId;
+    return result;
+  }
+}

--- a/src/Venue.ts
+++ b/src/Venue.ts
@@ -12,6 +12,7 @@ import { Auth, NoAuth } from './Credentials';
 import { Resolver } from 'did-resolver'
 import { getResolver } from 'web-did-resolver'
 import { Job } from './Job';
+import { Agent } from './Agent';
 
 const webResolver = getResolver()
 const resolver = new Resolver(webResolver)
@@ -131,6 +132,16 @@ export class Venue implements VenueInterface {
    */
   async getJob(jobId: string): Promise<Job> {
     return this.jobs.get(jobId);
+  }
+
+  /**
+   * Get a lazy Agent handle for the given agent ID.
+   * No network round-trip — the agent is not verified to exist.
+   * @param agentId - Agent identifier
+   * @returns {Agent} An Agent instance bound to this venue
+   */
+  agent(agentId: string): Agent {
+    return new Agent(agentId, this);
   }
 
   /**

--- a/src/__tests__/Agent.test.ts
+++ b/src/__tests__/Agent.test.ts
@@ -1,0 +1,174 @@
+import { Agent, ChatSession } from '../Agent';
+
+function createMockAgents() {
+  return {
+    request: jest.fn().mockResolvedValue({ id: 'req-1', status: 'RUNNING' }),
+    message: jest.fn().mockResolvedValue({ agentId: 'a1', delivered: true }),
+    chat: jest.fn().mockResolvedValue({ agentId: 'a1', sessionId: 'sess-1', response: 'hello' }),
+    trigger: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'RUNNING' }),
+    query: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'SLEEPING' }),
+    suspend: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'SUSPENDED' }),
+    resume: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'SLEEPING' }),
+    update: jest.fn().mockResolvedValue({}),
+    cancelTask: jest.fn().mockResolvedValue({}),
+    info: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'SLEEPING' }),
+    fork: jest.fn().mockResolvedValue({ agentId: 'a2', status: 'SLEEPING', created: true, forkedFrom: 'a1' }),
+    context: jest.fn().mockResolvedValue('context string'),
+    delete: jest.fn().mockResolvedValue({ agentId: 'a1', status: 'TERMINATED' }),
+  };
+}
+
+function createMockVenue(agents = createMockAgents()) {
+  return { agents } as any;
+}
+
+describe('Agent', () => {
+  let mockAgents: ReturnType<typeof createMockAgents>;
+  let venue: ReturnType<typeof createMockVenue>;
+  let agent: Agent;
+
+  beforeEach(() => {
+    mockAgents = createMockAgents();
+    venue = createMockVenue(mockAgents);
+    agent = new Agent('a1', venue);
+  });
+
+  it('stores id and venue', () => {
+    expect(agent.id).toBe('a1');
+    expect(agent.venue).toBe(venue);
+  });
+
+  it('request delegates to agents.request', async () => {
+    await agent.request({ prompt: 'hi' }, true);
+    expect(mockAgents.request).toHaveBeenCalledWith('a1', { prompt: 'hi' }, true);
+  });
+
+  it('message delegates to agents.message', async () => {
+    await agent.message({ text: 'hello' });
+    expect(mockAgents.message).toHaveBeenCalledWith('a1', { text: 'hello' });
+  });
+
+  it('chat delegates to agents.chat', async () => {
+    await agent.chat('hello');
+    expect(mockAgents.chat).toHaveBeenCalledWith('a1', 'hello', undefined);
+  });
+
+  it('chat passes sessionId when provided', async () => {
+    await agent.chat('follow up', 'sess-1');
+    expect(mockAgents.chat).toHaveBeenCalledWith('a1', 'follow up', 'sess-1');
+  });
+
+  it('trigger delegates to agents.trigger', async () => {
+    await agent.trigger();
+    expect(mockAgents.trigger).toHaveBeenCalledWith('a1');
+  });
+
+  it('query delegates to agents.query', async () => {
+    await agent.query();
+    expect(mockAgents.query).toHaveBeenCalledWith('a1');
+  });
+
+  it('suspend delegates to agents.suspend', async () => {
+    await agent.suspend();
+    expect(mockAgents.suspend).toHaveBeenCalledWith('a1');
+  });
+
+  it('resume delegates to agents.resume', async () => {
+    await agent.resume(false);
+    expect(mockAgents.resume).toHaveBeenCalledWith('a1', false);
+  });
+
+  it('update delegates to agents.update with bound agentId', async () => {
+    await agent.update({ config: { op: 'test' }, state: { x: 1 } });
+    expect(mockAgents.update).toHaveBeenCalledWith({ agentId: 'a1', config: { op: 'test' }, state: { x: 1 } });
+  });
+
+  it('cancelTask delegates to agents.cancelTask', async () => {
+    await agent.cancelTask('task-42');
+    expect(mockAgents.cancelTask).toHaveBeenCalledWith('a1', 'task-42');
+  });
+
+  it('info delegates to agents.info', async () => {
+    await agent.info();
+    expect(mockAgents.info).toHaveBeenCalledWith('a1');
+  });
+
+  it('fork delegates to agents.fork and returns new Agent', async () => {
+    const forked = await agent.fork('a2', { includeTimeline: true });
+    expect(mockAgents.fork).toHaveBeenCalledWith({ sourceId: 'a1', agentId: 'a2', includeTimeline: true });
+    expect(forked).toBeInstanceOf(Agent);
+    expect(forked.id).toBe('a2');
+    expect(forked.venue).toBe(venue);
+  });
+
+  it('context delegates to agents.context', async () => {
+    await agent.context({ goal: 'test' });
+    expect(mockAgents.context).toHaveBeenCalledWith('a1', { goal: 'test' });
+  });
+
+  it('context works without task', async () => {
+    await agent.context();
+    expect(mockAgents.context).toHaveBeenCalledWith('a1', undefined);
+  });
+
+  it('delete delegates to agents.delete', async () => {
+    await agent.delete(true);
+    expect(mockAgents.delete).toHaveBeenCalledWith('a1', true);
+  });
+
+  it('chatSession returns a ChatSession bound to this agent', () => {
+    const session = agent.chatSession();
+    expect(session).toBeInstanceOf(ChatSession);
+    expect(session.agent).toBe(agent);
+  });
+
+  it('chatSession accepts an existing sessionId for resuming', () => {
+    const session = agent.chatSession('existing-sid');
+    expect(session.sessionId).toBe('existing-sid');
+  });
+});
+
+describe('ChatSession', () => {
+  let mockAgents: ReturnType<typeof createMockAgents>;
+  let agent: Agent;
+
+  beforeEach(() => {
+    mockAgents = createMockAgents();
+    const venue = createMockVenue(mockAgents);
+    agent = new Agent('a1', venue);
+  });
+
+  it('sessionId is undefined before first send', () => {
+    const session = new ChatSession(agent);
+    expect(session.sessionId).toBeUndefined();
+  });
+
+  it('first send omits sessionId and captures it from result', async () => {
+    const session = new ChatSession(agent);
+    const result = await session.send('hi');
+    expect(mockAgents.chat).toHaveBeenCalledWith('a1', 'hi', undefined);
+    expect(session.sessionId).toBe('sess-1');
+    expect(result.sessionId).toBe('sess-1');
+  });
+
+  it('subsequent sends pass the captured sessionId', async () => {
+    const session = new ChatSession(agent);
+    await session.send('hi');
+    mockAgents.chat.mockResolvedValue({ agentId: 'a1', sessionId: 'sess-1', response: 'world' });
+    await session.send('and?');
+    expect(mockAgents.chat).toHaveBeenCalledWith('a1', 'and?', 'sess-1');
+  });
+
+  it('pre-loaded sessionId is used on first send', async () => {
+    const session = new ChatSession(agent, 'existing-sid');
+    expect(session.sessionId).toBe('existing-sid');
+    await session.send('resume');
+    expect(mockAgents.chat).toHaveBeenCalledWith('a1', 'resume', 'existing-sid');
+  });
+
+  it('returns full AgentChatResult', async () => {
+    const session = new ChatSession(agent);
+    const result = await session.send('hi');
+    expect(result).toEqual({ agentId: 'a1', sessionId: 'sess-1', response: 'hello' });
+  });
+});

--- a/src/__tests__/AgentManager.test.ts
+++ b/src/__tests__/AgentManager.test.ts
@@ -50,12 +50,12 @@ describe('AgentManager', () => {
     expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/trigger', { agentId: 'a1' });
   });
 
-  it('query calls agent:info and covia:read for state', async () => {
+  it('query calls v/ops/agent/info and v/ops/covia/read for state', async () => {
     await agents.query('a1');
-    expect(venue.operations.run).toHaveBeenCalledWith('agent:info', { agentId: 'a1' });
-    expect(venue.operations.run).toHaveBeenCalledWith('covia:read', { path: 'g/a1/timeline' });
-    expect(venue.operations.run).toHaveBeenCalledWith('covia:read', { path: 'g/a1/state' });
-    expect(venue.operations.run).toHaveBeenCalledWith('covia:read', { path: 'g/a1/inbox' });
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/agent/info', { agentId: 'a1' });
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/covia/read', { path: 'g/a1/timeline' });
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/covia/read', { path: 'g/a1/state' });
+    expect(venue.operations.run).toHaveBeenCalledWith('v/ops/covia/read', { path: 'g/a1/inbox' });
   });
 
   it('list calls v/ops/agent/list', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Asset } from './Asset';
 export { Operation } from './Operation';
 export { DataAsset } from './DataAsset';
 export { Job } from './Job';
+export { Agent, ChatSession } from './Agent';
 export { AgentManager } from './AgentManager';
 export { AssetManager } from './AssetManager';
 export { JobManager } from './JobManager';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Agent } from "./Agent";
 import { Asset } from "./Asset";
 import { Auth } from "./Credentials";
 import { Job } from "./Job";
@@ -38,6 +39,7 @@ export interface VenueInterface {
   listSecrets(): Promise<string[]>;
   putSecret(name: string, value: string): Promise<void>;
   deleteSecret(name: string): Promise<void>;
+  agent(agentId: string): Agent;
   close(): void;
 
 }


### PR DESCRIPTION
## Summary
- Adds `Agent` class — a lazy, ID-bound handle with instance methods (`chat`, `info`, `suspend`, `resume`, `fork`, etc.) that delegate to `AgentManager`
- Adds `ChatSession` class — manages `sessionId` state so callers don't need to thread it manually across `send()` calls
- Adds `venue.agent(id)` factory on `Venue` (sync, no round trip)
- Bumps version to `1.5.0`
- Keeps `AgentManager` unchanged for backward compatibility

## Test plan
- [x] Unit tests for all 13 Agent instance methods (delegation + bound ID)
- [x] Unit tests for ChatSession (sessionId minting, reuse, resume)
- [x] All 242 existing + new unit tests pass
- [x] `pnpm build` produces clean CJS + ESM + type declarations
- [x] Frontend tested against local SDK link — tests and build pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)