### PR TITLE
Fix missing auth headers on JobManager.get() and list()

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1573,11 +1573,15 @@ var JobManager = class {
     this.venue = venue;
   }
   async list() {
-    return fetchWithError(`${this.venue.baseUrl}/api/v1/jobs`);
+    return fetchWithError(`${this.venue.baseUrl}/api/v1/jobs`, {
+      headers: this._buildHeaders()
+    });
   }
   async get(jobId) {
     try {
-      const data = await fetchWithError(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`);
+      const data = await fetchWithError(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`, {
+        headers: this._buildHeaders()
+      });
       return new Job(jobId, this.venue, data);
     } catch (error) {
       if (error instanceof NotFoundError) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1571,11 +1571,15 @@ var JobManager = class {
     this.venue = venue;
   }
   async list() {
-    return fetchWithError(`${this.venue.baseUrl}/api/v1/jobs`);
+    return fetchWithError(`${this.venue.baseUrl}/api/v1/jobs`, {
+      headers: this._buildHeaders()
+    });
   }
   async get(jobId) {
     try {
-      const data = await fetchWithError(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`);
+      const data = await fetchWithError(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`, {
+        headers: this._buildHeaders()
+      });
       return new Job(jobId, this.venue, data);
     } catch (error) {
       if (error instanceof NotFoundError) {

--- a/src/JobManager.ts
+++ b/src/JobManager.ts
@@ -11,12 +11,16 @@ export class JobManager {
   constructor(private venue: JobManagerVenue) {}
 
   async list(): Promise<string[]> {
-    return fetchWithError<string[]>(`${this.venue.baseUrl}/api/v1/jobs`);
+    return fetchWithError<string[]>(`${this.venue.baseUrl}/api/v1/jobs`, {
+      headers: this._buildHeaders(),
+    });
   }
 
   async get(jobId: string): Promise<Job> {
     try {
-      const data = await fetchWithError<any>(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`);
+      const data = await fetchWithError<any>(`${this.venue.baseUrl}/api/v1/jobs/${jobId}`, {
+        headers: this._buildHeaders(),
+      });
       return new Job(jobId, this.venue as any, data);
     } catch (error) {
       if (error instanceof NotFoundError) {


### PR DESCRIPTION
## Summary
- `JobManager.get()` and `JobManager.list()` were not sending authentication headers on their HTTP requests
- This caused 403 "Access denied to job" errors when polling agent request/chat jobs, since the server couldn't identify the caller to match against the job's owner DID
- Adds `headers: this._buildHeaders()` to both methods, consistent with all other JobManager methods (cancel, delete, pause, resume, sendMessage)

## Test plan
- [x] Verified against live venue (venue-3.covia.ai) — `agent.request()` and `chat.send()` now complete successfully
- [x] All existing SDK unit tests pass (`pnpm test`)
- [x] Frontend build and all 57 tests pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)